### PR TITLE
fix : 군바 몬스터, 아이템 이동 방식 수정

### DIFF
--- a/FireFlower.cpp
+++ b/FireFlower.cpp
@@ -52,9 +52,6 @@ void FireFlower::Update()
     if (isDead == true)
         return;
 
-    //nowTileIndexX = (pos.x + GLOBAL_POS) / INGAME_RENDER_TILE_WIDHT_COUNT;
-    //nowTileIndexY = pos.y / MAP_HEIGHT;
-
     if (CollideWithPlayer() == true)
     {
         if (PLAYER->GetLevel() < 3)
@@ -91,7 +88,8 @@ void FireFlower::Release()
 
 void FireFlower::AutoMove()
 {
-    if (PLAYER->GetPos().x + PLAYER->GetCurrSpeed() > WIN_SIZE_X / 2)
+    if (PLAYER->GetPos().x + PLAYER->GetCurrSpeed() > WIN_SIZE_X / 2
+        && PLAYER->GetIsGrowOrIsSmallingOrIsDead() == false)
     {
         pos.x -= PLAYER->GetCurrSpeed();
     }

--- a/Gunba.cpp
+++ b/Gunba.cpp
@@ -172,6 +172,10 @@ void Gunba::Update()
 
     if (isDying == true)
     {
+        if (PLAYER->GetCurrSpeed() + PLAYER->GetPos().x > WIN_SIZE_X / 2)
+        {
+            pos.x -= PLAYER->GetCurrSpeed();
+        }
         Trampled();
         return;
     }

--- a/Gunba.cpp
+++ b/Gunba.cpp
@@ -63,7 +63,6 @@ void Gunba::ChangeAnimationFrame()
         }
         elapsedTime = 0.0f;
     }
-    
 }
 
 void Gunba::UpdateCollider()
@@ -246,11 +245,10 @@ void Gunba::Release()
 
 void Gunba::Spawn(POINTFLOAT pos)
 {
-    cout << "!!!!" << endl;
     this->pos = pos;
     UpdateCollider();
-    elapsedTime = 0.0f;
 
+    elapsedTime = 0.0f;
     isDying = false;
     isDead = false;
     speed = -60.0f;

--- a/Gunba.cpp
+++ b/Gunba.cpp
@@ -76,7 +76,8 @@ void Gunba::UpdateCollider()
 
 void Gunba::UpdatePosition()
 {
-    if (PLAYER->GetCurrSpeed() + PLAYER->GetPos().x > WIN_SIZE_X / 2)
+    if (PLAYER->GetCurrSpeed() + PLAYER->GetPos().x > WIN_SIZE_X / 2 &&
+        PLAYER->GetIsGrowOrIsSmalling() == false)
     {
         pos.x += speed * DELETA_TIME - PLAYER->GetCurrSpeed();
     }
@@ -172,7 +173,8 @@ void Gunba::Update()
 
     if (isDying == true)
     {
-        if (PLAYER->GetCurrSpeed() + PLAYER->GetPos().x > WIN_SIZE_X / 2)
+        if (PLAYER->GetCurrSpeed() + PLAYER->GetPos().x > WIN_SIZE_X / 2
+            && PLAYER->GetIsGrowOrIsSmalling() == false)
         {
             pos.x -= PLAYER->GetCurrSpeed();
         }

--- a/Gunba.cpp
+++ b/Gunba.cpp
@@ -77,7 +77,7 @@ void Gunba::UpdateCollider()
 void Gunba::UpdatePosition()
 {
     if (PLAYER->GetCurrSpeed() + PLAYER->GetPos().x > WIN_SIZE_X / 2 &&
-        PLAYER->GetIsGrowOrIsSmalling() == false)
+        PLAYER->GetIsGrowOrIsSmallingOrIsDead() == false)
     {
         pos.x += speed * DELETA_TIME - PLAYER->GetCurrSpeed();
     }
@@ -174,7 +174,7 @@ void Gunba::Update()
     if (isDying == true)
     {
         if (PLAYER->GetCurrSpeed() + PLAYER->GetPos().x > WIN_SIZE_X / 2
-            && PLAYER->GetIsGrowOrIsSmalling() == false)
+            && PLAYER->GetIsGrowOrIsSmallingOrIsDead() == false)
         {
             pos.x -= PLAYER->GetCurrSpeed();
         }
@@ -191,7 +191,7 @@ void Gunba::Update()
     if (CollideWithPlayer() == true)
     {
         // À§¿¡¼­ ¹âÈù°Å¸é Á×±â
-        if (PLAYER->GetRect().bottom < pos.y)
+        if (PLAYER->GetRect().bottom < pos.y && PLAYER->GetIsGrowOrIsSmallingOrIsDead() == false)
         {
             PLAYER->AddJumpower(300.0f);
             Die();

--- a/MonsterManager.cpp
+++ b/MonsterManager.cpp
@@ -22,7 +22,7 @@ void MonsterManager::Update()
 {
 	if (spawnGlobalPos[monsterWave] < GLOBAL_POS && monsterWave < MAX_MONSTER_WAVE_COUNT - 1)
 	{
-		SpawnMonster({ WIN_SIZE_X - 10, spawnYpos[monsterWave] });
+		SpawnMonster({ WIN_SIZE_X - 1, spawnYpos[monsterWave] });
 		++monsterWave;
 	}
 

--- a/Mushroom.cpp
+++ b/Mushroom.cpp
@@ -7,7 +7,8 @@ void Mushroom::AutoMove()
 {
     if(moveDirection == MoveDirection::Right)
     {
-        if (PLAYER->GetCurrSpeed() + PLAYER->GetPos().x > WIN_SIZE_X / 2)
+        if (PLAYER->GetCurrSpeed() + PLAYER->GetPos().x > WIN_SIZE_X / 2
+            && PLAYER->GetIsGrowOrIsSmallingOrIsDead() == false)
         {
             pos.x += speed * DELETA_TIME - PLAYER->GetCurrSpeed();
         }
@@ -18,7 +19,8 @@ void Mushroom::AutoMove()
     }
     else
     {
-        if (PLAYER->GetCurrSpeed() + PLAYER->GetPos().x > WIN_SIZE_X / 2)
+        if (PLAYER->GetCurrSpeed() + PLAYER->GetPos().x > WIN_SIZE_X / 2
+            && PLAYER->GetIsGrowOrIsSmallingOrIsDead() == false)
         {
             pos.x -= speed * DELETA_TIME + PLAYER->GetCurrSpeed();
         }
@@ -94,7 +96,8 @@ void Mushroom::Update()
     }
     if (isSpawning == true)
     {
-        if (PLAYER->GetCurrSpeed() + PLAYER->GetPos().x > WIN_SIZE_X / 2)
+        if (PLAYER->GetCurrSpeed() + PLAYER->GetPos().x > WIN_SIZE_X / 2
+            && PLAYER->GetIsGrowOrIsSmallingOrIsDead() == false)
         {
             pos.x -= PLAYER->GetCurrSpeed();
         }

--- a/PlayerCharacter.h
+++ b/PlayerCharacter.h
@@ -88,7 +88,7 @@ public:
 
 	RECT GetRect() { return collider; }
 
-	bool GetIsGrowOrIsSmalling() { return isGrowing || isSmalling || isDead; }
+	bool GetIsGrowOrIsSmallingOrIsDead() { return isGrowing || isSmalling || isDead; }
 
 	void AddJumpower(float power);
 };

--- a/PlayerCharacter.h
+++ b/PlayerCharacter.h
@@ -88,7 +88,7 @@ public:
 
 	RECT GetRect() { return collider; }
 
-	bool GetIsGrowOrIsSmalling() { return isGrowing || isSmalling; }
+	bool GetIsGrowOrIsSmalling() { return isGrowing || isSmalling || isDead; }
 
 	void AddJumpower(float power);
 };

--- a/PlayerCharacter.h
+++ b/PlayerCharacter.h
@@ -88,6 +88,8 @@ public:
 
 	RECT GetRect() { return collider; }
 
+	bool GetIsGrowOrIsSmalling() { return isGrowing || isSmalling; }
+
 	void AddJumpower(float power);
 };
 

--- a/SpinCoin.cpp
+++ b/SpinCoin.cpp
@@ -5,7 +5,8 @@
 #include "Input.h"
 void SpinCoin::Move()
 {
-    if (PLAYER->GetPos().x + PLAYER->GetCurrSpeed() > WIN_SIZE_X / 2)
+    if (PLAYER->GetPos().x + PLAYER->GetCurrSpeed() > WIN_SIZE_X / 2
+        && PLAYER->GetIsGrowOrIsSmallingOrIsDead() == false)
     {
         pos.x -= PLAYER->GetCurrSpeed();
     }


### PR DESCRIPTION
플레이어가 커지기, 작아지기, 죽는 애니메이션 때는 GlobalPos의 영향을 받지 않도록 수정